### PR TITLE
Add scroll into checking whether element is overlapped and out of viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 14.0.0 (23.08.2021)
+
+Now `performMouseAction` scrolls to the passed element when it's not in the viewport.
+
+This is a breaking change and it may affect all the current tests due to the side effects that are caused by the scroll.
+
+
 ## 13.1.0 (19.08.2021)
 
 Now `performMouseAction` checks for overlapping node.

--- a/lib/page/performMouseAction.js
+++ b/lib/page/performMouseAction.js
@@ -30,8 +30,24 @@ const performMouseAction = async function performMouseAction(context, actionType
     return ({ status: STATUS.INVISIBLE });
   }
 
-  const overlappingNodeClassName = await context.page.evaluate(selectorNode => {
+  const overlappingNodeClassName = await context.page.evaluate(async selectorNode => {
+    const visibleRatio = await new Promise(resolve => {
+      const observer = new IntersectionObserver(entries => {
+        resolve(entries[0].intersectionRatio);
+        observer.disconnect();
+      });
+      observer.observe(selectorNode);
+    });
+
+    if (visibleRatio !== 1.0) {
+      selectorNode.scrollIntoView({
+        block: 'center',
+        inline: 'center',
+      });
+    }
+
     const { left, top } = selectorNode.getBoundingClientRect();
+
     const x = left + (selectorNode.clientWidth / 2);
     const y = top + (selectorNode.clientHeight / 2);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@funboxteam/phantom-lord",
-  "version": "13.1.0",
+  "version": "14.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funboxteam/phantom-lord",
-  "version": "13.1.0",
+  "version": "14.0.0",
   "description": "Handy API for Headless Chromium",
   "repository": {
     "type": "git",


### PR DESCRIPTION
[Last time](https://github.com/funbox/phantom-lord/pull/14) I was still not quite right when I removed the scroll to the element for which it is checked if there is an overlapping element. Without this scroll we could get error in testing in those places where for example we want to click on a button inside custom select if it is out of popup area and we have to scroll to it. Or in such case when we have a dialog with sticky header and we need to fill in some input which far below, we scroll to it, but it is bellow header. Code executed correctly but not like we considered.

Snippet was taken from [puppeteer code](https://github.com/puppeteer/puppeteer/blob/dd470c7a226a8422a938a7b0fffa58ffc6b78512/src/common/JSHandle.ts#L391-L407).