### PR TITLE
Improve objects stringification in debug logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 14.1.0 (30.08.2021)
+
+We've improved debug logging a bit.
+
+Earlier when user run Phantom Lord with `DEBUG=1` and there were logged objects in DevTools, 
+the objects were printed in debug logs like this:
+
+```
+filename.js verbose: CONSOLE: [object Object]
+```
+
+Now every logged object or array, or anything is readable:
+
+```
+filename.js verbose: CONSOLE: 1
+filename.js verbose: CONSOLE: string
+filename.js verbose: CONSOLE: null
+filename.js verbose: CONSOLE: undefined
+filename.js verbose: CONSOLE: [1,2,3]
+filename.js verbose: CONSOLE: {"a":1}
+filename.js verbose: CONSOLE: Symbol(symbol)
+filename.js verbose: CONSOLE: () => {}
+filename.js verbose: CONSOLE: function fn() {}
+```
+
+
 ## 14.0.0 (23.08.2021)
 
 Now `performMouseAction` scrolls to the passed element when it's not in the viewport.
@@ -11,7 +37,7 @@ This is a breaking change and it may affect all the current tests due to the sid
 
 Now `performMouseAction` checks for overlapping node.
 
-Exisiting tests might be broken due to the fact, that now this method and its
+Existing tests might be broken due to the fact, that now this method and its
 derivatives throw an error instead of making an action. But they were already 
 broken earlier, so this version actually fixes the behaviour.
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,15 @@ const proxyHandler = {
  * @returns {Promise<string>}
  */
 async function stringifyMessageHandle(handle) {
-  const res = await handle.executionContext().evaluate(m => String((m && m.stack) || m), handle);
+  const res = await handle.executionContext().evaluate(m => {
+    const valueToStringify = (m && m.stack) || m;
+
+    if (typeof valueToStringify === 'object') {
+      return JSON.stringify(valueToStringify);
+    }
+
+    return String(valueToStringify);
+  }, handle);
   return res;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@funboxteam/phantom-lord",
-  "version": "14.0.0",
+  "version": "14.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funboxteam/phantom-lord",
-  "version": "14.0.0",
+  "version": "14.1.0",
   "description": "Handy API for Headless Chromium",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Currently when I run Phantom Lord with `DEBUG=1` all the logged objects look like this:

![image](https://user-images.githubusercontent.com/6537798/131377044-13d84656-fcc8-4b8e-996f-2d6ef0b045d2.png)

This behavior is expected due to calling `String` for object stringification.

In the PR I replace `String` with `JSON.stringify` when the argument of `console.log` is an object. So the result looks like this:

![image](https://user-images.githubusercontent.com/6537798/131377251-a35c6266-8397-4024-9780-7932361c3a66.png)

Much better, I think.