### PR TITLE
Adding cookies via method setCookies before go to url

### DIFF
--- a/lib/commands/open.js
+++ b/lib/commands/open.js
@@ -1,5 +1,7 @@
 const initializePage = require('../page/initialize');
 const openPage = require('../page/open');
+const setPageCookies = require('../utils/setPageCookies');
+
 const { STATE } = require('../utils/constants');
 
 /**
@@ -23,6 +25,8 @@ module.exports = async function open(context, url, options) {
   }
 
   try {
+    await setPageCookies(context, url);
+
     await context.page.goto(url, options);
   } catch (e) {
     errorWithUsefulStack.message = `open page error: ${e.message}`;

--- a/lib/page/initialize.js
+++ b/lib/page/initialize.js
@@ -12,13 +12,9 @@ const initializePage = async function initializePage(context) {
     }
   });
 
-  await context.page.evaluateOnNewDocument((settings, cookies, stubs, lsItems) => {
+  await context.page.evaluateOnNewDocument((settings, stubs, lsItems) => {
     window.test = settings;
-    if (cookies.length > 0) {
-      cookies.forEach((cookie) => {
-        document.cookie = [cookie.name, cookie.value].join('=');
-      });
-    }
+
     if (stubs.length > 0) {
       window.stubs = [];
       stubs.forEach((stub) => {
@@ -33,7 +29,7 @@ const initializePage = async function initializePage(context) {
     }
 
     window.setPageInitialized();
-  }, context.testSettings, context.cookiesQueue, context.stubsQueue, context.localStorageItemsQueue);
+  }, context.testSettings, context.stubsQueue, context.localStorageItemsQueue);
 };
 
 module.exports = initializePage;

--- a/lib/utils/setPageCookies.js
+++ b/lib/utils/setPageCookies.js
@@ -1,0 +1,21 @@
+/**
+ * @param {!RemoteBrowser} context
+ * @param {string} url
+ */
+
+const setPageCookies = async function setPageCookies(context, url) {
+  if (!context.cookiesQueue.length) return;
+
+  try {
+    const { hostname } = new URL(url);
+
+    await context.page.setCookie(...context.cookiesQueue.map(cookie => ({
+      domain: hostname,
+      ...cookie,
+    })));
+  } catch (e) {
+    throw new Error(`setCookie error, cookiesQueue: [${context.cookiesQueue.map(cookie => JSON.stringify({ url, ...cookie })).join(',')}]`);
+  }
+};
+
+module.exports = setPageCookies;


### PR DESCRIPTION
По-русски.
Работая над одним проектом я обратил внимание, что в `phantom-lord` куки устанавливаются после перехода по ссылке (_метод [Page.goto()](https://pptr.dev/api/puppeteer.page.goto) осуществляет переход по переданной ссылке на подготовленной странице_). При этом сама страница (запрос к серверу `GET /адрес-страницы`) запрашивается без передаваемых кук в заголовке запроса.

Сейчас куки устанавливаются при вызове события [Page.evaluateOnNewDocument()](https://pptr.dev/api/puppeteer.page.evaluateonnewdocument/), которое запускается при открытии адреса страницы.

Пообщавшись с коллегой пришли к выводу, что возможно такой механизм установки кук использовался когда метода [Page.setCookie()](https://pptr.dev/api/puppeteer.page.setcookie/) не существовало. Сейчас в `phantom-lord` используется `puppeteer` версии 13, поддерживающий метод `setCookies`.

В своём MR я предлагаю изменить механизм установки кук переносом его из метода по событию `evaluateOnNewDocument` в метод [open()](https://github.com/funbox/phantom-lord/blob/master/lib/commands/open.js#L26) пакета `phantom-lord` перед вызовом метода перехода по ссылке `page.goto()`. При таком подходе куки будут устанавливаться до перехода по переданной ссылке и страница будет запрашиваться с бекенда с передачей кук в заголовке, а так как событие `evaluateOnNewDocument` выполняется каждый раз при передаче адреса страницы (`page.goto()`), то поведение получения кук из очереди никак не изменится, изменится только очерёдность (установка кук, открытие страницы вместо открытие страницы, установка кук).
